### PR TITLE
fix(minor): config change for windows

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -225,8 +225,8 @@ services:
     depends_on:
       redis:
         condition: service_started
-      management-api:
-        condition: service_started
+      # management-api:
+        # condition: service_started
       # management-api:
       #   condition: service_healthy
 


### PR DESCRIPTION
In windows, even with the current config of the management-api (in SDK) its giving an error message saying "service management-api is required by sdk-scheme-adapter but is disabled. Can be enabled by profiles [portal]"